### PR TITLE
Interoperable Package

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,6 @@
 language: php
 
 php:
-  - 5.3
   - 5.4
   - 5.5
   - 5.6

--- a/Tests/DelegatingDispatcherTest.php
+++ b/Tests/DelegatingDispatcherTest.php
@@ -26,7 +26,7 @@ class DelegatingDispatcherTest extends \PHPUnit_Framework_TestCase
 	{
 		$event = 'onTest';
 
-		$mockedDispatcher = $this->getMock('Joomla\Event\DispatcherInterface');
+		$mockedDispatcher = $this->getMock('Joomla\Event\Dispatcher');
 		$mockedDispatcher->expects($this->once())
 			->method('triggerEvent')
 			->with($event);

--- a/Tests/DispatcherTest.php
+++ b/Tests/DispatcherTest.php
@@ -425,7 +425,7 @@ class DispatcherTest extends \PHPUnit_Framework_TestCase
 			->addListener('onBeforeSomething', array($listener3, 'onBeforeSomething'));
 
 		// Remove the listener from a specific event.
-		$this->instance->removeListener(array($listener1, 'onBeforeSomething'), 'onBeforeSomething');
+		$this->instance->removeListener('onBeforeSomething', array($listener1, 'onBeforeSomething'));
 
 		$this->assertFalse($this->instance->hasListener(array($listener1, 'onBeforeSomething')));
 		$this->assertTrue($this->instance->hasListener(array($listener2, 'onBeforeSomething')));

--- a/Tests/DispatcherTest.php
+++ b/Tests/DispatcherTest.php
@@ -224,26 +224,6 @@ class DispatcherTest extends \PHPUnit_Framework_TestCase
 	}
 
 	/**
-	 * Test the addListener method with an empty listener (no methods).
-	 * It shouldn't be registered to any event.
-	 *
-	 * @return  void
-	 *
-	 * @covers  Joomla\Event\Dispatcher::addListener
-	 * @since   1.0
-	 */
-	public function testAddListenerEmpty()
-	{
-		$listener = new EmptyListener;
-		$this->instance->addListener($listener);
-
-		$this->assertFalse($this->instance->hasListener($listener));
-
-		$this->instance->addListener($listener, array('onSomething'));
-		$this->assertFalse($this->instance->hasListener($listener, 'onSomething'));
-	}
-
-	/**
 	 * Test the addListener method.
 	 *
 	 * @return  void
@@ -258,36 +238,39 @@ class DispatcherTest extends \PHPUnit_Framework_TestCase
 		$listener2 = new SomethingListener;
 		$listener3 = new SomethingListener;
 
-		$this->instance->addListener($listener1)
-			->addListener($listener2)
-			->addListener($listener3);
+		$this->instance->addListener('onBeforeSomething', array($listener1, 'onBeforeSomething'))
+			->addListener('onSomething', array($listener1, 'onSomething'))
+			->addListener('onAfterSomething', array($listener1, 'onAfterSomething'))
+			->addListener('onBeforeSomething', array($listener2, 'onBeforeSomething'))
+			->addListener('onSomething', array($listener2, 'onSomething'))
+			->addListener('onAfterSomething', array($listener2, 'onAfterSomething'))
+			->addListener('onBeforeSomething', array($listener3, 'onBeforeSomething'))
+			->addListener('onSomething', array($listener3, 'onSomething'))
+			->addListener('onAfterSomething', array($listener3, 'onAfterSomething'));
 
-		$this->assertTrue($this->instance->hasListener($listener1));
-		$this->assertTrue($this->instance->hasListener($listener1, 'onBeforeSomething'));
-		$this->assertTrue($this->instance->hasListener($listener1, 'onSomething'));
-		$this->assertTrue($this->instance->hasListener($listener1, 'onAfterSomething'));
+		$this->assertTrue($this->instance->hasListener(array($listener1, 'onBeforeSomething')));
+		$this->assertTrue($this->instance->hasListener(array($listener1, 'onSomething')));
+		$this->assertTrue($this->instance->hasListener(array($listener1, 'onAfterSomething')));
 
-		$this->assertTrue($this->instance->hasListener($listener2));
-		$this->assertTrue($this->instance->hasListener($listener2, 'onBeforeSomething'));
-		$this->assertTrue($this->instance->hasListener($listener2, 'onSomething'));
-		$this->assertTrue($this->instance->hasListener($listener2, 'onAfterSomething'));
+		$this->assertTrue($this->instance->hasListener(array($listener2, 'onBeforeSomething')));
+		$this->assertTrue($this->instance->hasListener(array($listener2, 'onSomething')));
+		$this->assertTrue($this->instance->hasListener(array($listener2, 'onAfterSomething')));
 
-		$this->assertTrue($this->instance->hasListener($listener3));
-		$this->assertTrue($this->instance->hasListener($listener3, 'onBeforeSomething'));
-		$this->assertTrue($this->instance->hasListener($listener3, 'onSomething'));
-		$this->assertTrue($this->instance->hasListener($listener3, 'onAfterSomething'));
+		$this->assertTrue($this->instance->hasListener(array($listener3, 'onBeforeSomething')));
+		$this->assertTrue($this->instance->hasListener(array($listener3, 'onSomething')));
+		$this->assertTrue($this->instance->hasListener(array($listener3, 'onAfterSomething')));
 
-		$this->assertEquals(Priority::NORMAL, $this->instance->getListenerPriority($listener1, 'onBeforeSomething'));
-		$this->assertEquals(Priority::NORMAL, $this->instance->getListenerPriority($listener1, 'onSomething'));
-		$this->assertEquals(Priority::NORMAL, $this->instance->getListenerPriority($listener1, 'onAfterSomething'));
+		$this->assertEquals(Priority::NORMAL, $this->instance->getListenerPriority('onBeforeSomething', array($listener1, 'onBeforeSomething')));
+		$this->assertEquals(Priority::NORMAL, $this->instance->getListenerPriority('onSomething', array($listener1, 'onSomething')));
+		$this->assertEquals(Priority::NORMAL, $this->instance->getListenerPriority('onAfterSomething', array($listener1, 'onAfterSomething')));
 
-		$this->assertEquals(Priority::NORMAL, $this->instance->getListenerPriority($listener1, 'onBeforeSomething'));
-		$this->assertEquals(Priority::NORMAL, $this->instance->getListenerPriority($listener1, 'onSomething'));
-		$this->assertEquals(Priority::NORMAL, $this->instance->getListenerPriority($listener1, 'onAfterSomething'));
+		$this->assertEquals(Priority::NORMAL, $this->instance->getListenerPriority('onBeforeSomething', array($listener2, 'onBeforeSomething')));
+		$this->assertEquals(Priority::NORMAL, $this->instance->getListenerPriority('onSomething', array($listener2, 'onSomething')));
+		$this->assertEquals(Priority::NORMAL, $this->instance->getListenerPriority('onAfterSomething', array($listener2, 'onAfterSomething')));
 
-		$this->assertEquals(Priority::NORMAL, $this->instance->getListenerPriority($listener3, 'onBeforeSomething'));
-		$this->assertEquals(Priority::NORMAL, $this->instance->getListenerPriority($listener3, 'onSomething'));
-		$this->assertEquals(Priority::NORMAL, $this->instance->getListenerPriority($listener3, 'onAfterSomething'));
+		$this->assertEquals(Priority::NORMAL, $this->instance->getListenerPriority('onBeforeSomething', array($listener3, 'onBeforeSomething')));
+		$this->assertEquals(Priority::NORMAL, $this->instance->getListenerPriority('onSomething', array($listener3, 'onSomething')));
+		$this->assertEquals(Priority::NORMAL, $this->instance->getListenerPriority('onAfterSomething', array($listener3, 'onAfterSomething')));
 	}
 
 	/**
@@ -302,47 +285,17 @@ class DispatcherTest extends \PHPUnit_Framework_TestCase
 	{
 		$listener = new SomethingListener;
 
-		$this->instance->addListener(
-			$listener,
-			array(
-				'onBeforeSomething' => Priority::MIN,
-				'onSomething' => Priority::ABOVE_NORMAL,
-				'onAfterSomething' => Priority::HIGH
-			)
-		);
+		$this->instance->addListener('onBeforeSomething', array($listener, 'onBeforeSomething'), Priority::MIN)
+			->addListener('onSomething', array($listener, 'onSomething'), Priority::ABOVE_NORMAL)
+			->addListener('onAfterSomething', array($listener, 'onAfterSomething'), Priority::MAX);
 
-		$this->assertTrue($this->instance->hasListener($listener, 'onBeforeSomething'));
-		$this->assertTrue($this->instance->hasListener($listener, 'onSomething'));
-		$this->assertTrue($this->instance->hasListener($listener, 'onAfterSomething'));
+		$this->assertTrue($this->instance->hasListener(array($listener, 'onBeforeSomething')));
+		$this->assertTrue($this->instance->hasListener(array($listener, 'onSomething')));
+		$this->assertTrue($this->instance->hasListener(array($listener, 'onAfterSomething')));
 
-		$this->assertEquals(Priority::MIN, $this->instance->getListenerPriority($listener, 'onBeforeSomething'));
-		$this->assertEquals(Priority::ABOVE_NORMAL, $this->instance->getListenerPriority($listener, 'onSomething'));
-		$this->assertEquals(Priority::HIGH, $this->instance->getListenerPriority($listener, 'onAfterSomething'));
-	}
-
-	/**
-	 * Test the addListener method by specifying less events than its methods.
-	 *
-	 * @return  void
-	 *
-	 * @covers  Joomla\Event\Dispatcher::addListener
-	 * @since   1.0
-	 */
-	public function testAddListenerLessEvents()
-	{
-		$listener = new SomethingListener;
-
-		$this->instance->addListener(
-			$listener,
-			array(
-				'onBeforeSomething' => Priority::NORMAL,
-				'onAfterSomething' => Priority::HIGH
-			)
-		);
-
-		$this->assertFalse($this->instance->hasListener($listener, 'onSomething'));
-		$this->assertTrue($this->instance->hasListener($listener, 'onBeforeSomething'));
-		$this->assertTrue($this->instance->hasListener($listener, 'onAfterSomething'));
+		$this->assertEquals(Priority::MIN, $this->instance->getListenerPriority('onBeforeSomething', array($listener, 'onBeforeSomething')));
+		$this->assertEquals(Priority::ABOVE_NORMAL, $this->instance->getListenerPriority('onSomething', array($listener, 'onSomething')));
+		$this->assertEquals(Priority::MAX, $this->instance->getListenerPriority('onAfterSomething', array($listener, 'onAfterSomething')));
 	}
 
 	/**
@@ -391,21 +344,6 @@ class DispatcherTest extends \PHPUnit_Framework_TestCase
 
 			}
 		);
-	}
-
-	/**
-	 * Test the addListener method with an invalid listener.
-	 *
-	 * @expectedException  \InvalidArgumentException
-	 *
-	 * @return  void
-	 *
-	 * @covers  Joomla\Event\Dispatcher::addListener
-	 * @since   1.0
-	 */
-	public function testAddListenerInvalidListenerException()
-	{
-		$this->instance->addListener('foo');
 	}
 
 	/**

--- a/Tests/DispatcherTest.php
+++ b/Tests/DispatcherTest.php
@@ -436,30 +436,21 @@ class DispatcherTest extends \PHPUnit_Framework_TestCase
 	 */
 	public function testRemoveListeners()
 	{
-		$listener = new SomethingListener;
-		$this->instance->addListener($listener);
+		// Add 3 listeners listening to the same events.
+		$listener1 = new SomethingListener;
+		$listener2 = new SomethingListener;
+		$listener3 = new SomethingListener;
 
-		// Remove the listener from all events.
-		$this->instance->removeListener($listener);
-
-		$this->assertFalse($this->instance->hasListener($listener, 'onBeforeSomething'));
-		$this->assertFalse($this->instance->hasListener($listener, 'onSomething'));
-		$this->assertFalse($this->instance->hasListener($listener, 'onAfterSomething'));
-
-		$this->instance->addListener($listener);
+		$this->instance->addListener('onBeforeSomething', array($listener1, 'onBeforeSomething'))
+			->addListener('onBeforeSomething', array($listener2, 'onBeforeSomething'))
+			->addListener('onBeforeSomething', array($listener3, 'onBeforeSomething'));
 
 		// Remove the listener from a specific event.
-		$this->instance->removeListener($listener, 'onBeforeSomething');
+		$this->instance->removeListener(array($listener1, 'onBeforeSomething'), 'onBeforeSomething');
 
-		$this->assertFalse($this->instance->hasListener($listener, 'onBeforeSomething'));
-		$this->assertTrue($this->instance->hasListener($listener, 'onSomething'));
-		$this->assertTrue($this->instance->hasListener($listener, 'onAfterSomething'));
-
-		// Remove the listener from a specific event by passing an event object.
-		$this->instance->removeListener($listener, new Event('onSomething'));
-
-		$this->assertFalse($this->instance->hasListener($listener, 'onSomething'));
-		$this->assertTrue($this->instance->hasListener($listener, 'onAfterSomething'));
+		$this->assertFalse($this->instance->hasListener(array($listener1, 'onBeforeSomething')));
+		$this->assertTrue($this->instance->hasListener(array($listener2, 'onBeforeSomething')));
+		$this->assertTrue($this->instance->hasListener(array($listener3, 'onBeforeSomething')));
 	}
 
 	/**

--- a/Tests/ListenersPriorityQueueTest.php
+++ b/Tests/ListenersPriorityQueueTest.php
@@ -34,29 +34,14 @@ class ListenersPriorityQueueTest extends \PHPUnit_Framework_TestCase
 	 */
 	public function testAdd()
 	{
-		$listener1 = new EmptyListener;
-		$listener2 = new EmptyListener;
-		$listener3 = function() {
+		$listener = function() {
 
 		};
-		$listener4 = new EmptyListener;
 
-		$this->instance->add($listener1, 5);
-		$this->instance->add($listener2, 5);
-		$this->instance->add($listener3, 0);
-		$this->instance->add($listener4, -100);
+		$this->instance->add($listener, 0);
 
-		$this->assertTrue($this->instance->has($listener1));
-		$this->assertEquals(5, $this->instance->getPriority($listener1));
-
-		$this->assertTrue($this->instance->has($listener2));
-		$this->assertEquals(5, $this->instance->getPriority($listener2));
-
-		$this->assertTrue($this->instance->has($listener3));
-		$this->assertEquals(0, $this->instance->getPriority($listener3));
-
-		$this->assertTrue($this->instance->has($listener4));
-		$this->assertEquals(-100, $this->instance->getPriority($listener4));
+		$this->assertTrue($this->instance->has($listener));
+		$this->assertEquals(0, $this->instance->getPriority($listener));
 	}
 
 	/**
@@ -68,7 +53,9 @@ class ListenersPriorityQueueTest extends \PHPUnit_Framework_TestCase
 	 */
 	public function testAddExisting()
 	{
-		$listener = new EmptyListener;
+		$listener = function() {
+
+		};
 
 		$this->instance->add($listener, 5);
 		$this->instance->add($listener, 0);
@@ -86,7 +73,11 @@ class ListenersPriorityQueueTest extends \PHPUnit_Framework_TestCase
 	 */
 	public function testGetPriorityNonExisting()
 	{
-		$this->assertNull($this->instance->getPriority(new EmptyListener));
+		$listener = function() {
+
+		};
+
+		$this->assertNull($this->instance->getPriority($listener));
 
 		$this->assertFalse(
 			$this->instance->getPriority(
@@ -107,36 +98,35 @@ class ListenersPriorityQueueTest extends \PHPUnit_Framework_TestCase
 	 */
 	public function testRemove()
 	{
-		$listener1 = new EmptyListener;
-		$listener2 = new EmptyListener;
-		$listener3 = function() {
+		$listener1 = function() {
 
 		};
-		$listener4 = new EmptyListener;
+
+		$listener2 = function() {
+			return false;
+		};
 
 		$this->instance->add($listener1, 0);
-		$this->instance->add($listener2, 0);
-		$this->instance->add($listener3, 0);
 
 		// Removing a non existing listener has no effect.
-		$this->instance->remove($listener4);
+		$this->instance->remove($listener2);
+
+		$this->assertTrue($this->instance->has($listener1));
+
+		$this->instance->add($listener2, 0);
 
 		$this->assertTrue($this->instance->has($listener1));
 		$this->assertTrue($this->instance->has($listener2));
-		$this->assertTrue($this->instance->has($listener3));
 
 		$this->instance->remove($listener1);
 
 		$this->assertFalse($this->instance->has($listener1));
 		$this->assertTrue($this->instance->has($listener2));
-		$this->assertTrue($this->instance->has($listener3));
 
 		$this->instance->remove($listener2);
-		$this->instance->remove($listener3);
 
 		$this->assertFalse($this->instance->has($listener1));
 		$this->assertFalse($this->instance->has($listener2));
-		$this->assertFalse($this->instance->has($listener3));
 	}
 
 	/**
@@ -152,52 +142,21 @@ class ListenersPriorityQueueTest extends \PHPUnit_Framework_TestCase
 	{
 		$this->assertEmpty($this->instance->getAll());
 
-		$listener0 = new EmptyListener;
-		$listener1 = new EmptyListener;
-		$listener2 = new EmptyListener;
-
-		$listener3 = function() {
+		$listener0 = function() {
 
 		};
 
-		$listener4 = new EmptyListener;
-		$listener5 = new EmptyListener;
-
-		$listener6 = function() {
-
+		$listener1 = function() {
+			return false;
 		};
-
-		$listener7 = new EmptyListener;
-
-		$listener8 = function() {
-
-		};
-
-		$listener9 = new EmptyListener;
 
 		$this->instance->add($listener0, 10);
 		$this->instance->add($listener1, 3);
-		$this->instance->add($listener2, 3);
-		$this->instance->add($listener3, 3);
-		$this->instance->add($listener4, 3);
-		$this->instance->add($listener5, 2);
-		$this->instance->add($listener6, 2);
-		$this->instance->add($listener7, 2);
-		$this->instance->add($listener8, 0);
-		$this->instance->add($listener9, -10);
 
 		$listeners = $this->instance->getAll();
 
 		$this->assertSame($listeners[0], $listener0);
 		$this->assertSame($listeners[1], $listener1);
-		$this->assertSame($listeners[2], $listener2);
-		$this->assertSame($listeners[3], $listener3);
-		$this->assertSame($listeners[4], $listener4);
-		$this->assertSame($listeners[5], $listener5);
-		$this->assertSame($listeners[6], $listener6);
-		$this->assertSame($listeners[7], $listener7);
-		$this->assertSame($listeners[8], $listener8);
-		$this->assertSame($listeners[9], $listener9);
 	}
 
 	/**
@@ -209,39 +168,16 @@ class ListenersPriorityQueueTest extends \PHPUnit_Framework_TestCase
 	 */
 	public function testGetIterator()
 	{
-		$listener0 = new EmptyListener;
-		$listener1 = new EmptyListener;
-		$listener2 = new EmptyListener;
-
-		$listener3 = function() {
+		$listener0 = function() {
 
 		};
 
-		$listener4 = new EmptyListener;
-		$listener5 = new EmptyListener;
-
-		$listener6 = function() {
-
+		$listener1 = function() {
+			return false;
 		};
-
-		$listener7 = new EmptyListener;
-
-		$listener8 = function() {
-
-		};
-
-		$listener9 = new EmptyListener;
 
 		$this->instance->add($listener0, 10);
 		$this->instance->add($listener1, 3);
-		$this->instance->add($listener2, 3);
-		$this->instance->add($listener3, 3);
-		$this->instance->add($listener4, 3);
-		$this->instance->add($listener5, 2);
-		$this->instance->add($listener6, 2);
-		$this->instance->add($listener7, 2);
-		$this->instance->add($listener8, 0);
-		$this->instance->add($listener9, -10);
 
 		$listeners = array();
 
@@ -252,14 +188,6 @@ class ListenersPriorityQueueTest extends \PHPUnit_Framework_TestCase
 
 		$this->assertSame($listeners[0], $listener0);
 		$this->assertSame($listeners[1], $listener1);
-		$this->assertSame($listeners[2], $listener2);
-		$this->assertSame($listeners[3], $listener3);
-		$this->assertSame($listeners[4], $listener4);
-		$this->assertSame($listeners[5], $listener5);
-		$this->assertSame($listeners[6], $listener6);
-		$this->assertSame($listeners[7], $listener7);
-		$this->assertSame($listeners[8], $listener8);
-		$this->assertSame($listeners[9], $listener9);
 	}
 
 	/**
@@ -271,13 +199,16 @@ class ListenersPriorityQueueTest extends \PHPUnit_Framework_TestCase
 	 */
 	public function testGetIteratorMultipleIterations()
 	{
-		$listener0 = new EmptyListener;
-		$listener1 = new EmptyListener;
-		$listener2 = new EmptyListener;
+		$listener0 = function() {
+
+		};
+
+		$listener1 = function() {
+			return false;
+		};
 
 		$this->instance->add($listener0, 0);
 		$this->instance->add($listener1, 1);
-		$this->instance->add($listener2, 2);
 
 		$firstListeners = array();
 
@@ -307,8 +238,13 @@ class ListenersPriorityQueueTest extends \PHPUnit_Framework_TestCase
 	{
 		$this->assertCount(0, $this->instance);
 
-		$listener1 = new EmptyListener;
-		$listener2 = new EmptyListener;
+		$listener1 = function() {
+
+		};
+
+		$listener2 = function() {
+			return false;
+		};
 
 		$this->instance->add($listener1, 0);
 		$this->instance->add($listener2, 0);

--- a/composer.json
+++ b/composer.json
@@ -6,7 +6,7 @@
     "homepage": "https://github.com/joomla-framework/event",
     "license": "GPL-2.0+",
     "require": {
-        "php": ">=5.3.10"
+        "php": ">=5.4"
     },
     "require-dev": {
         "phpunit/phpunit": "4.*",

--- a/src/AbstractEvent.php
+++ b/src/AbstractEvent.php
@@ -23,7 +23,6 @@ abstract class AbstractEvent implements EventInterface, ArrayAccess, Serializabl
 	 * The event name.
 	 *
 	 * @var    string
-	 *
 	 * @since  1.0
 	 */
 	protected $name;
@@ -32,7 +31,6 @@ abstract class AbstractEvent implements EventInterface, ArrayAccess, Serializabl
 	 * The event arguments.
 	 *
 	 * @var    array
-	 *
 	 * @since  1.0
 	 */
 	protected $arguments;
@@ -41,7 +39,6 @@ abstract class AbstractEvent implements EventInterface, ArrayAccess, Serializabl
 	 * A flag to see if the event propagation is stopped.
 	 *
 	 * @var    boolean
-	 *
 	 * @since  1.0
 	 */
 	protected $stopped = false;
@@ -109,8 +106,7 @@ abstract class AbstractEvent implements EventInterface, ArrayAccess, Serializabl
 	/**
 	 * Get all event arguments.
 	 *
-	 * @return  array  An associative array of argument names as keys
-	 *                 and their values as values.
+	 * @return  array  An associative array of argument names as keys and their values as values.
 	 *
 	 * @since   1.0
 	 */
@@ -129,6 +125,18 @@ abstract class AbstractEvent implements EventInterface, ArrayAccess, Serializabl
 	public function isStopped()
 	{
 		return true === $this->stopped;
+	}
+
+	/**
+	 * Stops the propagation of the event to further event listeners.
+	 *
+	 * @return  void
+	 *
+	 * @since   __DEPLOY_VERSION__
+	 */
+	public function stopPropagation()
+	{
+		$this->stopped = true;
 	}
 
 	/**

--- a/src/DelegatingDispatcher.php
+++ b/src/DelegatingDispatcher.php
@@ -69,18 +69,16 @@ final class DelegatingDispatcher implements DispatcherInterface
 	/**
 	 * Removes an event listener from the specified event.
 	 *
-	 * If no event is specified, it will be removed from all events it is listening to.
-	 *
-	 * @param   callable  $callback   The listener to remove.
 	 * @param   string    $eventName  The event to remove a listener from.
+	 * @param   callable  $callback   The listener to remove.
 	 *
 	 * @return  void
 	 *
 	 * @since   __DEPLOY_VERSION__
 	 */
-	public function removeListener(callable $listener, $eventName = null)
+	public function removeListener($eventName, callable $listener)
 	{
-		$this->dispatcher->removeListener($listener, $eventName);
+		$this->dispatcher->removeListener($eventName, $listener);
 	}
 
 	/**

--- a/src/DelegatingDispatcher.php
+++ b/src/DelegatingDispatcher.php
@@ -67,6 +67,23 @@ final class DelegatingDispatcher implements DispatcherInterface
 	}
 
 	/**
+	 * Removes an event listener from the specified event.
+	 *
+	 * If no event is specified, it will be removed from all events it is listening to.
+	 *
+	 * @param   callable  $callback   The listener to remove.
+	 * @param   string    $eventName  The event to remove a listener from.
+	 *
+	 * @return  void
+	 *
+	 * @since   __DEPLOY_VERSION__
+	 */
+	public function removeListener(callable $listener, $eventName = null)
+	{
+		$this->dispatcher->removeListener($listener, $eventName);
+	}
+
+	/**
 	 * Trigger an event.
 	 *
 	 * @param   EventInterface|string  $event  The event object or name.

--- a/src/DelegatingDispatcher.php
+++ b/src/DelegatingDispatcher.php
@@ -9,7 +9,7 @@
 namespace Joomla\Event;
 
 /**
- * A dispatcher delegating its methods to an other dispatcher.
+ * A dispatcher delegating its methods to another dispatcher.
  *
  * @since  1.0
  */
@@ -19,7 +19,6 @@ final class DelegatingDispatcher implements DispatcherInterface
 	 * The delegated dispatcher.
 	 *
 	 * @var    DispatcherInterface
-	 *
 	 * @since  1.0
 	 */
 	private $dispatcher;
@@ -34,6 +33,37 @@ final class DelegatingDispatcher implements DispatcherInterface
 	public function __construct(DispatcherInterface $dispatcher)
 	{
 		$this->dispatcher = $dispatcher;
+	}
+
+	/**
+	 * Attaches a listener to an event
+	 *
+	 * @param   string    $eventName  The event to listen to.
+	 * @param   callable  $callback   A callable function
+	 * @param   integer   $priority   The priority at which the $callback executed
+	 *
+	 * @return  boolean
+	 *
+	 * @since   __DEPLOY_VERSION__
+	 */
+	public function addListener($eventName, callable $callback, $priority = Priority::NORMAL)
+	{
+		return $this->dispatcher->addListener($eventName, $callback, $priority);
+	}
+
+	/**
+	 * Dispatches an event to all registered listeners.
+	 *
+	 * @param   string          $name   The name of the event to dispatch.
+	 * @param   EventInterface  $event  The event to pass to the event handlers/listeners.
+	 *
+	 * @return  EventInterface  The event after being passed through all listeners.
+	 *
+	 * @since   __DEPLOY_VERSION__
+	 */
+	public function dispatch($name, EventInterface $event = null)
+	{
+		return $this->dispatcher->dispatch($name, $event);
 	}
 
 	/**

--- a/src/Dispatcher.php
+++ b/src/Dispatcher.php
@@ -270,30 +270,18 @@ class Dispatcher implements DispatcherInterface
 	/**
 	 * Removes an event listener from the specified event.
 	 *
-	 * If no event is specified, it will be removed from all events it is listening to.
-	 *
-	 * @param   callable  $callback   The listener to remove.
 	 * @param   string    $eventName  The event to remove a listener from.
+	 * @param   callable  $callback   The listener to remove.
 	 *
 	 * @return  void
 	 *
-	 * @since   1.0
+	 * @since   __DEPLOY_VERSION__
 	 */
-	public function removeListener(callable $listener, $eventName = null)
+	public function removeListener($eventName, callable $listener)
 	{
-		if ($eventName)
+		if (isset($this->listeners[$eventName]))
 		{
-			if (isset($this->listeners[$eventName]))
-			{
-				$this->listeners[$eventName]->remove($listener);
-			}
-		}
-		else
-		{
-			foreach ($this->listeners as $queue)
-			{
-				$queue->remove($listener);
-			}
+			$this->listeners[$eventName]->remove($listener);
 		}
 	}
 

--- a/src/Dispatcher.php
+++ b/src/Dispatcher.php
@@ -419,27 +419,20 @@ class Dispatcher implements DispatcherInterface
 	}
 
 	/**
-	 * Trigger an event.
+	 * Dispatches an event to all registered listeners.
 	 *
-	 * @param   EventInterface|string  $event  The event object or name.
+	 * @param   string          $name   The name of the event to dispatch.
+	 * @param   EventInterface  $event  The event to pass to the event handlers/listeners.
 	 *
-	 * @return  EventInterface  The event after being passed through all listeners.
+	 * @return  EventInterface
 	 *
-	 * @since   1.0
+	 * @since   __DEPLOY_VERSION__
 	 */
-	public function triggerEvent($event)
+	public function dispatch($name, EventInterface $event = null)
 	{
 		if (!($event instanceof EventInterface))
 		{
-			if (isset($this->events[$event]))
-			{
-				$event = $this->events[$event];
-			}
-
-			else
-			{
-				$event = new Event($event);
-			}
+			$event = $this->getDefaultEvent($name);
 		}
 
 		if (isset($this->listeners[$event->getName()]))
@@ -455,7 +448,6 @@ class Dispatcher implements DispatcherInterface
 				{
 					call_user_func($listener, $event);
 				}
-
 				else
 				{
 					call_user_func(array($listener, $event->getName()), $event);
@@ -464,5 +456,44 @@ class Dispatcher implements DispatcherInterface
 		}
 
 		return $event;
+	}
+
+	/**
+	 * Trigger an event.
+	 *
+	 * @param   EventInterface|string  $event  The event object or name.
+	 *
+	 * @return  EventInterface  The event after being passed through all listeners.
+	 *
+	 * @since   1.0
+	 * @deprecated  3.0  Use dispatch() instead.
+	 */
+	public function triggerEvent($event)
+	{
+		if (!($event instanceof EventInterface))
+		{
+			$event = $this->getDefaultEvent($event);
+		}
+
+		return $this->dispatch($event->getName(), $event);
+	}
+
+	/**
+	 * Get an event object for the specified event name
+	 *
+	 * @param   string  $name  The event name to get an EventInterface object for
+	 *
+	 * @return  EventInterface
+	 *
+	 * @since   __DEPLOY_VERSION__
+	 */
+	private function getDefaultEvent($name)
+	{
+		if (isset($this->events[$event]))
+		{
+			return $this->events[$event];
+		}
+
+		return new Event($event);
 	}
 }

--- a/src/Dispatcher.php
+++ b/src/Dispatcher.php
@@ -268,32 +268,26 @@ class Dispatcher implements DispatcherInterface
 	}
 
 	/**
-	 * Remove the given listener from this dispatcher.
+	 * Removes an event listener from the specified event.
 	 *
 	 * If no event is specified, it will be removed from all events it is listening to.
 	 *
-	 * @param   object|Closure         $listener  The listener to remove.
-	 * @param   EventInterface|string  $event     The event object or name.
+	 * @param   callable  $callback   The listener to remove.
+	 * @param   string    $eventName  The event to remove a listener from.
 	 *
-	 * @return  Dispatcher  This method is chainable.
+	 * @return  void
 	 *
 	 * @since   1.0
 	 */
-	public function removeListener($listener, $event = null)
+	public function removeListener(callable $listener, $eventName = null)
 	{
-		if ($event)
+		if ($eventName)
 		{
-			if ($event instanceof EventInterface)
+			if (isset($this->listeners[$eventName]))
 			{
-				$event = $event->getName();
-			}
-
-			if (isset($this->listeners[$event]))
-			{
-				$this->listeners[$event]->remove($listener);
+				$this->listeners[$eventName]->remove($listener);
 			}
 		}
-
 		else
 		{
 			foreach ($this->listeners as $queue)
@@ -301,8 +295,6 @@ class Dispatcher implements DispatcherInterface
 				$queue->remove($listener);
 			}
 		}
-
-		return $this;
 	}
 
 	/**

--- a/src/Dispatcher.php
+++ b/src/Dispatcher.php
@@ -38,7 +38,7 @@ class Dispatcher implements DispatcherInterface
 	 *
 	 * @param   EventInterface  $event  The event.
 	 *
-	 * @return  Dispatcher  This method is chainable.
+	 * @return  $this
 	 *
 	 * @since   1.0
 	 */
@@ -54,7 +54,7 @@ class Dispatcher implements DispatcherInterface
 	 *
 	 * @param   EventInterface  $event  The event.
 	 *
-	 * @return  Dispatcher  This method is chainable.
+	 * @return  $this
 	 *
 	 * @since   1.0
 	 */
@@ -112,7 +112,7 @@ class Dispatcher implements DispatcherInterface
 	 *
 	 * @param   EventInterface|string  $event  The event object or name.
 	 *
-	 * @return  Dispatcher  This method is chainable.
+	 * @return  $this
 	 *
 	 * @since   1.0
 	 */
@@ -302,9 +302,9 @@ class Dispatcher implements DispatcherInterface
 	 *
 	 * If an event is specified, the listeners will be cleared only for that event.
 	 *
-	 * @param   EventInterface|string  $event  The event object or name.
+	 * @param   string  $event  The event name.
 	 *
-	 * @return  Dispatcher  This method is chainable.
+	 * @return  $this
 	 *
 	 * @since   1.0
 	 */
@@ -312,17 +312,11 @@ class Dispatcher implements DispatcherInterface
 	{
 		if ($event)
 		{
-			if ($event instanceof EventInterface)
-			{
-				$event = $event->getName();
-			}
-
 			if (isset($this->listeners[$event]))
 			{
 				unset($this->listeners[$event]);
 			}
 		}
-
 		else
 		{
 			$this->listeners = array();
@@ -334,7 +328,7 @@ class Dispatcher implements DispatcherInterface
 	/**
 	 * Count the number of registered listeners for the given event.
 	 *
-	 * @param   EventInterface|string  $event  The event object or name.
+	 * @param   string  $event  The event name.
 	 *
 	 * @return  integer  The number of registered listeners for the given event.
 	 *
@@ -342,11 +336,6 @@ class Dispatcher implements DispatcherInterface
 	 */
 	public function countListeners($event)
 	{
-		if ($event instanceof EventInterface)
-		{
-			$event = $event->getName();
-		}
-
 		return isset($this->listeners[$event]) ? count($this->listeners[$event]) : 0;
 	}
 
@@ -376,14 +365,7 @@ class Dispatcher implements DispatcherInterface
 					return $event;
 				}
 
-				if ($listener instanceof Closure)
-				{
-					call_user_func($listener, $event);
-				}
-				else
-				{
-					call_user_func(array($listener, $event->getName()), $event);
-				}
+				call_user_func($listener, $event);
 			}
 		}
 
@@ -421,11 +403,11 @@ class Dispatcher implements DispatcherInterface
 	 */
 	private function getDefaultEvent($name)
 	{
-		if (isset($this->events[$event]))
+		if (isset($this->events[$name]))
 		{
-			return $this->events[$event];
+			return $this->events[$name];
 		}
 
-		return new Event($event);
+		return new Event($name);
 	}
 }

--- a/src/DispatcherInterface.php
+++ b/src/DispatcherInterface.php
@@ -41,4 +41,16 @@ interface DispatcherInterface
 	 * @since   __DEPLOY_VERSION__
 	 */
 	public function dispatch($name, EventInterface $event = null);
+
+	/**
+	 * Removes an event listener from the specified event.
+	 *
+	 * If no event is specified, it will be removed from all events it is listening to.
+	 *
+	 * @param   callable  $callback   The listener to remove.
+	 * @param   string    $eventName  The event to remove a listener from.
+	 *
+	 * @return void
+	 */
+	public function removeListener(callable $listener, $eventName = null);
 }

--- a/src/DispatcherInterface.php
+++ b/src/DispatcherInterface.php
@@ -16,13 +16,16 @@ namespace Joomla\Event;
 interface DispatcherInterface
 {
 	/**
-	 * Trigger an event.
+	 * Dispatches an event to all registered listeners.
 	 *
-	 * @param   EventInterface|string  $event  The event object or name.
+	 * @param   string          $name   The name of the event to dispatch.
+	 *                                  The name of the event is the name of the method that is invoked on listeners.
+	 * @param   EventInterface  $event  The event to pass to the event handlers/listeners.
+	 *                                  If not supplied, an empty EventInterface instance is created.
 	 *
-	 * @return  EventInterface  The event after being passed through all listeners.
+	 * @return  EventInterface
 	 *
-	 * @since   1.0
+	 * @since   __DEPLOY_VERSION__
 	 */
-	public function triggerEvent($event);
+	public function dispatch($name, EventInterface $event = null);
 }

--- a/src/DispatcherInterface.php
+++ b/src/DispatcherInterface.php
@@ -16,6 +16,19 @@ namespace Joomla\Event;
 interface DispatcherInterface
 {
 	/**
+	 * Attaches a listener to an event
+	 *
+	 * @param   string    $eventName  The event to listen to.
+	 * @param   callable  $callback   A callable function.
+	 * @param   integer   $priority   The priority at which the $callback executed.
+	 *
+	 * @return  boolean
+	 *
+	 * @since   __DEPLOY_VERSION__
+	 */
+	public function addListener($eventName, callable $callback, $priority = Priority::NORMAL);
+
+	/**
 	 * Dispatches an event to all registered listeners.
 	 *
 	 * @param   string          $name   The name of the event to dispatch.

--- a/src/DispatcherInterface.php
+++ b/src/DispatcherInterface.php
@@ -45,12 +45,12 @@ interface DispatcherInterface
 	/**
 	 * Removes an event listener from the specified event.
 	 *
-	 * If no event is specified, it will be removed from all events it is listening to.
-	 *
-	 * @param   callable  $callback   The listener to remove.
 	 * @param   string    $eventName  The event to remove a listener from.
+	 * @param   callable  $callback   The listener to remove.
 	 *
-	 * @return void
+	 * @return  void
+	 *
+	 * @since   __DEPLOY_VERSION__
 	 */
-	public function removeListener(callable $listener, $eventName = null);
+	public function removeListener($eventName, callable $listener);
 }

--- a/src/Event.php
+++ b/src/Event.php
@@ -23,7 +23,7 @@ class Event extends AbstractEvent
 	 * @param   string  $name   The argument name.
 	 * @param   mixed   $value  The argument value.
 	 *
-	 * @return  Event  This method is chainable.
+	 * @return  $this
 	 *
 	 * @since   1.0
 	 */
@@ -36,15 +36,13 @@ class Event extends AbstractEvent
 
 		return $this;
 	}
-
 	/**
-	 * Set the value of an event argument.
-	 * If the argument already exists, it will be overridden.
+	 * Add argument to event.
 	 *
-	 * @param   string  $name   The argument name.
-	 * @param   mixed   $value  The argument value.
+	 * @param   string  $key    Argument name.
+	 * @param   mixed   $value  Value.
 	 *
-	 * @return  Event  This method is chainable.
+	 * @return  $this
 	 *
 	 * @since   1.0
 	 */
@@ -98,10 +96,11 @@ class Event extends AbstractEvent
 	 * @return  void
 	 *
 	 * @since   1.0
+	 * @deprecated  3.0  Use stopPropogation instead
 	 */
 	public function stop()
 	{
-		$this->stopped = true;
+		$this->stopPropagation();
 	}
 
 	/**
@@ -112,9 +111,8 @@ class Event extends AbstractEvent
 	 *
 	 * @return  void
 	 *
-	 * @throws  InvalidArgumentException  If the argument name is null.
-	 *
 	 * @since   1.0
+	 * @throws  InvalidArgumentException  If the argument name is null.
 	 */
 	public function offsetSet($name, $value)
 	{

--- a/src/EventImmutable.php
+++ b/src/EventImmutable.php
@@ -57,6 +57,28 @@ final class EventImmutable extends AbstractEvent
 	}
 
 	/**
+	 * Add argument to event.
+	 *
+	 * @param   string  $key    Argument name.
+	 * @param   mixed   $value  Value.
+	 *
+	 * @return  void
+	 *
+	 * @since   __DEPLOY_VERSION__
+	 * @throws  BadMethodCallException
+	 */
+	public function setArgument($name, $value)
+	{
+		throw new BadMethodCallException(
+			sprintf(
+				'Cannot set the argument %s of the immutable event %s.',
+				$name,
+				$this->name
+			)
+		);
+	}
+
+	/**
 	 * Set the value of an event argument.
 	 *
 	 * @param   string  $name   The argument name.
@@ -64,9 +86,8 @@ final class EventImmutable extends AbstractEvent
 	 *
 	 * @return  void
 	 *
-	 * @throws  BadMethodCallException
-	 *
 	 * @since   1.0
+	 * @throws  BadMethodCallException
 	 */
 	public function offsetSet($name, $value)
 	{

--- a/src/EventImmutable.php
+++ b/src/EventImmutable.php
@@ -57,28 +57,6 @@ final class EventImmutable extends AbstractEvent
 	}
 
 	/**
-	 * Add argument to event.
-	 *
-	 * @param   string  $key    Argument name.
-	 * @param   mixed   $value  Value.
-	 *
-	 * @return  void
-	 *
-	 * @since   __DEPLOY_VERSION__
-	 * @throws  BadMethodCallException
-	 */
-	public function setArgument($name, $value)
-	{
-		throw new BadMethodCallException(
-			sprintf(
-				'Cannot set the argument %s of the immutable event %s.',
-				$name,
-				$this->name
-			)
-		);
-	}
-
-	/**
 	 * Set the value of an event argument.
 	 *
 	 * @param   string  $name   The argument name.

--- a/src/EventInterface.php
+++ b/src/EventInterface.php
@@ -10,7 +10,7 @@ namespace Joomla\Event;
 
 /**
  * Interface for events.
- * An event has a name and its propagation can be stopped (if the implementation supports it).
+ * An event has a name and its propagation can be stopped.
  *
  * @since  1.0
  */

--- a/src/EventInterface.php
+++ b/src/EventInterface.php
@@ -17,6 +17,18 @@ namespace Joomla\Event;
 interface EventInterface
 {
 	/**
+	 * Get an event argument value.
+	 *
+	 * @param   string  $name     The argument name.
+	 * @param   mixed   $default  The default value if not found.
+	 *
+	 * @return  mixed  The argument value or the default value.
+	 *
+	 * @since   __DEPLOY_VERSION__
+	 */
+	public function getArgument($name, $default = null);
+
+	/**
 	 * Get the event name.
 	 *
 	 * @return  string  The event name.
@@ -33,4 +45,25 @@ interface EventInterface
 	 * @since   1.0
 	 */
 	public function isStopped();
+
+	/**
+	 * Add argument to event.
+	 *
+	 * @param   string  $key    Argument name.
+	 * @param   mixed   $value  Value.
+	 *
+	 * @return  EventInterface
+	 *
+	 * @since   __DEPLOY_VERSION__
+	 */
+	public function setArgument($name, $value);
+
+	/**
+	 * Stops the propagation of the event to further event listeners.
+	 *
+	 * @return  void
+	 *
+	 * @since   __DEPLOY_VERSION__
+	 */
+	public function stopPropagation();
 }

--- a/src/EventInterface.php
+++ b/src/EventInterface.php
@@ -47,18 +47,6 @@ interface EventInterface
 	public function isStopped();
 
 	/**
-	 * Add argument to event.
-	 *
-	 * @param   string  $key    Argument name.
-	 * @param   mixed   $value  Value.
-	 *
-	 * @return  EventInterface
-	 *
-	 * @since   __DEPLOY_VERSION__
-	 */
-	public function setArgument($name, $value);
-
-	/**
 	 * Stops the propagation of the event to further event listeners.
 	 *
 	 * @return  void

--- a/src/ListenersPriorityQueue.php
+++ b/src/ListenersPriorityQueue.php
@@ -60,15 +60,19 @@ class ListenersPriorityQueue extends \SplPriorityQueue
 	{
 		if ($this->has($callback))
 		{
-			$this->storage->detach($listener);
-			$this->storage->rewind();
+			// Clone ourselves to retain the existing queue data
+			$self = clone $this;
+			$self->setExtractFlags(self::EXTR_BOTH);
 
-			$this->queue = new SplPriorityQueue;
+			// And now clear our queue
+			$this->extract();
 
-			foreach ($this->storage as $listener)
+			foreach ($self as $listener)
 			{
-				$priority = $this->storage->getInfo();
-				$this->queue->insert($listener, $priority);
+				if ($listener['data'] !== $callback)
+				{
+					$this->insert($listener['data'], $listener['priority']);
+				}
 			}
 		}
 

--- a/src/ListenersPriorityQueue.php
+++ b/src/ListenersPriorityQueue.php
@@ -8,81 +8,40 @@
 
 namespace Joomla\Event;
 
-use SplPriorityQueue;
-use SplObjectStorage;
-use IteratorAggregate;
-use Countable;
-
 /**
  * A class containing an inner listeners priority queue that can be iterated multiple times.
  * One instance of ListenersPriorityQueue is used per Event in the Dispatcher.
  *
  * @since  1.0
  */
-class ListenersPriorityQueue implements IteratorAggregate, Countable
+class ListenersPriorityQueue extends \SplPriorityQueue
 {
 	/**
-	 * The inner priority queue.
-	 *
-	 * @var    SplPriorityQueue
-	 *
-	 * @since  1.0
-	 */
-	protected $queue;
-
-	/**
-	 * A copy of the listeners contained in the queue
-	 * that is used when detaching them to
-	 * recreate the queue or to see if the queue contains
-	 * a given listener.
-	 *
-	 * @var    SplObjectStorage
-	 *
-	 * @since  1.0
-	 */
-	protected $storage;
-
-	/**
-	 * A decreasing counter used to compute
-	 * the internal priority as an array because
-	 * SplPriorityQueue dequeues elements with the same priority.
+	 * A decreasing counter used to compute the internal priority as an array because SplPriorityQueue dequeues elements with the same priority.
 	 *
 	 * @var    integer
-	 *
 	 * @since  1.0
 	 */
 	private $counter = PHP_INT_MAX;
 
 	/**
-	 * Constructor.
-	 *
-	 * @since  1.0
-	 */
-	public function __construct()
-	{
-		$this->queue = new SplPriorityQueue;
-		$this->storage = new SplObjectStorage;
-	}
-
-	/**
 	 * Add a listener with the given priority only if not already present.
 	 *
-	 * @param   \Closure|object  $listener  The listener.
-	 * @param   integer          $priority  The listener priority.
+	 * @param   callable  $callback   A callable function acting as an event listener.
+	 * @param   integer   $priority   The listener priority.
 	 *
-	 * @return  ListenersPriorityQueue  This method is chainable.
+	 * @return  $this
 	 *
 	 * @since   1.0
 	 */
-	public function add($listener, $priority)
+	public function add(callable $callback, $priority)
 	{
-		if (!$this->storage->contains($listener))
+		if (!$this->has($callback))
 		{
 			// Compute the internal priority as an array.
 			$priority = array($priority, $this->counter--);
 
-			$this->storage->attach($listener, $priority);
-			$this->queue->insert($listener, $priority);
+			$this->insert($callback, $priority);
 		}
 
 		return $this;
@@ -91,15 +50,15 @@ class ListenersPriorityQueue implements IteratorAggregate, Countable
 	/**
 	 * Remove a listener from the queue.
 	 *
-	 * @param   \Closure|object  $listener  The listener.
+	 * @param   callable  $callback  A callable function acting as an event listener.
 	 *
-	 * @return  ListenersPriorityQueue  This method is chainable.
+	 * @return  $this
 	 *
 	 * @since   1.0
 	 */
-	public function remove($listener)
+	public function remove(callable $callback)
 	{
-		if ($this->storage->contains($listener))
+		if ($this->has($callback))
 		{
 			$this->storage->detach($listener);
 			$this->storage->rewind();
@@ -119,32 +78,48 @@ class ListenersPriorityQueue implements IteratorAggregate, Countable
 	/**
 	 * Tell if the listener exists in the queue.
 	 *
-	 * @param   \Closure|object  $listener  The listener.
+	 * @param   callable  $callback  A callable function acting as an event listener.
 	 *
 	 * @return  boolean  True if it exists, false otherwise.
 	 *
 	 * @since   1.0
 	 */
-	public function has($listener)
+	public function has(callable $callback)
 	{
-		return $this->storage->contains($listener);
+		$self = clone $this;
+
+		foreach ($self as $item)
+		{
+			if ($item === $callback)
+			{
+				return true;
+			}
+		}
+
+		return false;
 	}
 
 	/**
 	 * Get the priority of the given listener.
 	 *
-	 * @param   \Closure|object  $listener  The listener.
-	 * @param   mixed            $default   The default value to return if the listener doesn't exist.
+	 * @param   callable  $callback  A callable function acting as an event listener.
+	 * @param   mixed     $default   The default value to return if the listener doesn't exist.
 	 *
-	 * @return  mixed  The listener priority if it exists, null otherwise.
+	 * @return  mixed  The listener priority if it exists or the specified default value
 	 *
 	 * @since   1.0
 	 */
-	public function getPriority($listener, $default = null)
+	public function getPriority(callable $callback, $default = null)
 	{
-		if ($this->storage->contains($listener))
+		$self = clone $this;
+		$self->setExtractFlags(self::EXTR_BOTH);
+
+		foreach ($self as $item)
 		{
-			return $this->storage[$listener][0];
+			if ($item['data'] === $callback)
+			{
+				return $item['priority'][0];
+			}
 		}
 
 		return $default;
@@ -173,16 +148,16 @@ class ListenersPriorityQueue implements IteratorAggregate, Countable
 	}
 
 	/**
-	 * Get the inner queue with its cursor on top of the heap.
+	 * Get the priority queue with its cursor on top of the heap.
 	 *
-	 * @return  SplPriorityQueue  The inner queue.
+	 * @return  $this
 	 *
 	 * @since   1.0
 	 */
 	public function getIterator()
 	{
 		// SplPriorityQueue queue is a heap.
-		$queue = clone $this->queue;
+		$queue = clone $this;
 
 		if (!$queue->isEmpty())
 		{
@@ -190,17 +165,5 @@ class ListenersPriorityQueue implements IteratorAggregate, Countable
 		}
 
 		return $queue;
-	}
-
-	/**
-	 * Count the number of listeners in the queue.
-	 *
-	 * @return  integer  The number of listeners in the queue.
-	 *
-	 * @since   1.0
-	 */
-	public function count()
-	{
-		return count($this->queue);
 	}
 }

--- a/src/Priority.php
+++ b/src/Priority.php
@@ -9,8 +9,7 @@
 namespace Joomla\Event;
 
 /**
- * An enumeration of priorities for event listeners,
- * that you are encouraged to use when adding them in the Dispatcher.
+ * An enumeration of priorities for event listeners that you are encouraged to use when adding them in the Dispatcher.
  *
  * @since  1.0
  */
@@ -23,4 +22,13 @@ final class Priority
 	const ABOVE_NORMAL = 1;
 	const HIGH = 2;
 	const MAX = 3;
+
+	/**
+	 * Disallow instantiation of this class
+	 *
+	 * @since   1.0
+	 */
+	private function __construct()
+	{
+	}
 }


### PR DESCRIPTION
This is a refactoring of the event package for improved interoperability with the PHP community (based primarily on the Symfony Event Dispatcher as that appears to be the most widely used event system with others emulating it in some ways).

## Major Changes

### PHP 5.4 Dependency

The package typehints for callables, this is a PHP 5.4 feature.

### Refactored DispatcherInterface

The most disruptive change is to the `DispatcherInterface`.  The `triggerEvent` is removed from the interface (retained in the `Dispatcher` class) and the interface now composes of `addListener`, `dispatch`, and `removeListener`.  The `addListener` and `removeListener` methods are refactored to adjust how listeners are managed; now an event name and a callable are required to be given to both methods (with `addListener` now supporting priorities by the method's signature instead of embedded into the old `$events` array).

### Refactored Dispatcher

The dispatcher previously behaved as a combined event listener and subscriber (using Symfony logic) and would try to register all of a listener class' public methods as listeners for dispatched events.  Now, methods must be explicitly registered through `addListener`.  The refactored method requires the event name to be specified and the callable to be triggered when an event is dispatched.  The `Dispatcher` class retains the current `triggerEvent` method, flagged as deprecated for 3.0, and proxies it into the now preferred `dispatch` method.

The `getListenerPriority` method signature is changed to require the event name and callable to check the priority for.

The `hasListener` method requires the first parameter to be the callable to check for existence, the second optional parameter is the event name to check if the callable is registered for.

The `Dispatcher` class continues support registration of `Event` objects to be dispatched for a given event name, and an internal method checks for this before using a base `Event` object.

### DelegatingDispatcher class changes

The `DelegatingDispatcher` class is updated to implement all required interface changes.

### Refactored EventInterface

The `EventInterface` adds two required methods for implementations of this interface: `getArgument` and `stopPropagation`.  Events are now required to expose an API to retrieve event arguments (even if immutable) and implement a `stopPropagation` method to instruct the dispatcher to stop propagating the event.

### Event class changes

The `stop` method in the Event class is deprecated in favor of the `stopPropagation` interface method.  This method will be removed in 3.0.

### Refactored ListenersPriorityQueue

The `ListenersPriorityQueue` class is refactored to use an internal storage array eliminating the `SplPriorityQueue` and `SplObjectStorage` storage mechanisms and the internals of this class are restructured for this change.  For methods where the listener was an argument, these are now typehinted as callables similar to the `Dispatcher` the class is typically used with.