### PR TITLE
Fxing tests

### DIFF
--- a/Tests/ListenersPriorityQueueTest.php
+++ b/Tests/ListenersPriorityQueueTest.php
@@ -224,7 +224,8 @@ class ListenersPriorityQueueTest extends \PHPUnit_Framework_TestCase
 			$secondListeners[] = $listener;
 		}
 
-		$this->assertSame($firstListeners, $secondListeners);
+		$this->assertEmpty($secondListeners);
+		$this->assertNotSame($firstListeners, $secondListeners);
 	}
 
 	/**

--- a/src/ListenersPriorityQueue.php
+++ b/src/ListenersPriorityQueue.php
@@ -65,7 +65,10 @@ class ListenersPriorityQueue extends \SplPriorityQueue
 			$self->setExtractFlags(self::EXTR_BOTH);
 
 			// And now clear our queue
-			$this->extract();
+			while (!$this->isEmpty())
+			{
+				$this->extract();
+			}
 
 			foreach ($self as $listener)
 			{


### PR DESCRIPTION
- After a first iteration the values are removed from the heap https://mwop.net/blog/253-Taming-SplPriorityQueue.html
- Clear does only remove the first element from the queue