### PR TITLE
Getting the items should follow the queue character

### DIFF
--- a/Tests/ListenersPriorityQueueTest.php
+++ b/Tests/ListenersPriorityQueueTest.php
@@ -160,6 +160,41 @@ class ListenersPriorityQueueTest extends \PHPUnit_Framework_TestCase
 	}
 
 	/**
+	 * Test the getAll method multiple times.
+	 * The queue behavior must be correct, items which are get from the
+	 * queue must be removed.
+	 *
+	 * @return  void
+	 *
+	 * @since   1.0
+	 */
+	public function testGetAllMultipleTimes()
+	{
+		$this->assertEmpty($this->instance->getAll());
+
+		$listener0 = function() {
+
+		};
+
+		$listener1 = function() {
+			return false;
+		};
+
+		$this->instance->add($listener0, 10);
+		$this->instance->add($listener1, 3);
+
+		$listeners = $this->instance->getAll();
+
+		$this->assertSame($listeners[0], $listener0);
+		$this->assertSame($listeners[1], $listener1);
+
+		$listeners1 = $this->instance->getAll();
+
+		$this->assertEmpty($listeners1);
+		$this->assertNotSame($listeners, $listeners1);
+	}
+
+	/**
 	 * Test the getIterator method.
 	 *
 	 * @return  void

--- a/src/ListenersPriorityQueue.php
+++ b/src/ListenersPriorityQueue.php
@@ -140,10 +140,7 @@ class ListenersPriorityQueue extends \SplPriorityQueue
 	{
 		$listeners = array();
 
-		// Get a clone of the queue.
-		$queue = $this->getIterator();
-
-		foreach ($queue as $listener)
+		foreach ($this as $listener)
 		{
 			$listeners[] = $listener;
 		}
@@ -160,14 +157,11 @@ class ListenersPriorityQueue extends \SplPriorityQueue
 	 */
 	public function getIterator()
 	{
-		// SplPriorityQueue queue is a heap.
-		$queue = clone $this;
-
-		if (!$queue->isEmpty())
+		if (!$this->isEmpty())
 		{
-			$queue->top();
+			$this->top();
 		}
 
-		return $queue;
+		return $this;
 	}
 }


### PR DESCRIPTION
The character of a queue should be kept also on some helper functions like getAll or getIterator.