### PR TITLE
[2.0] Create an interface describing dispatchers which manage subscribers

### DIFF
--- a/src/Dispatcher.php
+++ b/src/Dispatcher.php
@@ -13,7 +13,7 @@ namespace Joomla\Event;
  *
  * @since  1.0
  */
-class Dispatcher implements DispatcherInterface
+class Dispatcher implements DispatcherInterface, SubscriberManagerInterface
 {
 	/**
 	 * An array of registered events indexed by the event names.
@@ -330,7 +330,7 @@ class Dispatcher implements DispatcherInterface
 	 *
 	 * @param   SubscriberInterface  $subscriber  The subscriber.
 	 *
-	 * @return  $this
+	 * @return  void
 	 *
 	 * @since   __DEPLOY_VERSION__
 	 */

--- a/src/SubscriberManagerInterface.php
+++ b/src/SubscriberManagerInterface.php
@@ -1,0 +1,39 @@
+<?php
+/**
+ * Part of the Joomla Framework Event Package
+ *
+ * @copyright  Copyright (C) 2005 - 2016 Open Source Matters, Inc. All rights reserved.
+ * @license    GNU General Public License version 2 or later; see LICENSE
+ */
+
+namespace Joomla\Event;
+
+/**
+ * Interface for event dispatchers which manage event subscribers.
+ *
+ * @since  __DEPLOY_VERSION__
+ */
+interface SubscriberManagerInterface
+{
+	/**
+	 * Adds an event subscriber.
+	 *
+	 * @param   SubscriberInterface  $subscriber  The subscriber.
+	 *
+	 * @return  void
+	 *
+	 * @since   __DEPLOY_VERSION__
+	 */
+	public function addSubscriber(SubscriberInterface $subscriber);
+
+	/**
+	 * Removes an event subscriber.
+	 *
+	 * @param   SubscriberInterface  $subscriber  The subscriber.
+	 *
+	 * @return  void
+	 *
+	 * @since   __DEPLOY_VERSION__
+	 */
+	public function removeSubscriber(SubscriberInterface $subscriber);
+}


### PR DESCRIPTION
### Summary of Changes

Right now there is not an interface describing dispatchers which support subscribers, only individual listeners.  This PR adds a new `SubscriberManagerInterface` for this purpose.

I opted for a separate interface instead of including the methods in the `DispatcherInterface` as this will in part lessen the number of API breaks between major versions and not force a dispatcher implementation to support subscribers if so desired.

### Testing Instructions

Code review.