### PR TITLE
Deprecate support for default event objects

### DIFF
--- a/src/DelegatingDispatcher.php
+++ b/src/DelegatingDispatcher.php
@@ -70,6 +70,8 @@ class DelegatingDispatcher implements DispatcherInterface
 	 *
 	 * @param   string          $name   The name of the event to dispatch.
 	 * @param   EventInterface  $event  The event to pass to the event handlers/listeners.
+	 *                                  If not supplied, an empty EventInterface instance is created.
+	 *                                  Note, not passing an event is deprecated and will be required as of 3.0.
 	 *
 	 * @return  EventInterface  The event after being passed through all listeners.
 	 *

--- a/src/Dispatcher.php
+++ b/src/Dispatcher.php
@@ -20,6 +20,7 @@ class Dispatcher implements DispatcherInterface
 	 *
 	 * @var    EventInterface[]
 	 * @since  1.0
+	 * @deprecated  3.0  Default event objects will no longer be supported
 	 */
 	protected $events = [];
 
@@ -39,6 +40,7 @@ class Dispatcher implements DispatcherInterface
 	 * @return  $this
 	 *
 	 * @since   1.0
+	 * @deprecated  3.0  Default event objects will no longer be supported
 	 */
 	public function setEvent(EventInterface $event)
 	{
@@ -55,6 +57,7 @@ class Dispatcher implements DispatcherInterface
 	 * @return  $this
 	 *
 	 * @since   1.0
+	 * @deprecated  3.0  Default event objects will no longer be supported
 	 */
 	public function addEvent(EventInterface $event)
 	{
@@ -74,6 +77,7 @@ class Dispatcher implements DispatcherInterface
 	 * @return  boolean  True if the listener has the given event, false otherwise.
 	 *
 	 * @since   1.0
+	 * @deprecated  3.0  Default event objects will no longer be supported
 	 */
 	public function hasEvent($event)
 	{
@@ -94,6 +98,7 @@ class Dispatcher implements DispatcherInterface
 	 * @return  EventInterface|mixed  The event of the default value.
 	 *
 	 * @since   1.0
+	 * @deprecated  3.0  Default event objects will no longer be supported
 	 */
 	public function getEvent($name, $default = null)
 	{
@@ -113,6 +118,7 @@ class Dispatcher implements DispatcherInterface
 	 * @return  $this
 	 *
 	 * @since   1.0
+	 * @deprecated  3.0  Default event objects will no longer be supported
 	 */
 	public function removeEvent($event)
 	{
@@ -135,6 +141,7 @@ class Dispatcher implements DispatcherInterface
 	 * @return  EventInterface[]  The registered event.
 	 *
 	 * @since   1.0
+	 * @deprecated  3.0  Default event objects will no longer be supported
 	 */
 	public function getEvents()
 	{
@@ -147,6 +154,7 @@ class Dispatcher implements DispatcherInterface
 	 * @return  EventInterface[]  The old events.
 	 *
 	 * @since   1.0
+	 * @deprecated  3.0  Default event objects will no longer be supported
 	 */
 	public function clearEvents()
 	{
@@ -162,6 +170,7 @@ class Dispatcher implements DispatcherInterface
 	 * @return  integer  The numer of registered events.
 	 *
 	 * @since   1.0
+	 * @deprecated  3.0  Default event objects will no longer be supported
 	 */
 	public function countEvents()
 	{
@@ -388,6 +397,8 @@ class Dispatcher implements DispatcherInterface
 	 *
 	 * @param   string          $name   The name of the event to dispatch.
 	 * @param   EventInterface  $event  The event to pass to the event handlers/listeners.
+	 *                                  If not supplied, an empty EventInterface instance is created.
+	 *                                  Note, not passing an event is deprecated and will be required as of 3.0.
 	 *
 	 * @return  EventInterface
 	 *
@@ -397,6 +408,14 @@ class Dispatcher implements DispatcherInterface
 	{
 		if (!($event instanceof EventInterface))
 		{
+			@trigger_error(
+				sprintf(
+					'Not passing an event object to %s() is deprecated, as of 3.0 the $event argument will be required.',
+					__METHOD__
+				),
+				E_USER_DEPRECATED
+			);
+
 			$event = $this->getDefaultEvent($name);
 		}
 
@@ -453,6 +472,7 @@ class Dispatcher implements DispatcherInterface
 	 * @return  EventInterface
 	 *
 	 * @since   __DEPLOY_VERSION__
+	 * @deprecated  3.0  Default event objects will no longer be supported
 	 */
 	private function getDefaultEvent(string $name): EventInterface
 	{

--- a/src/DispatcherInterface.php
+++ b/src/DispatcherInterface.php
@@ -19,9 +19,9 @@ interface DispatcherInterface
 	 * Dispatches an event to all registered listeners.
 	 *
 	 * @param   string          $name   The name of the event to dispatch.
-	 *                                  The name of the event is the name of the method that is invoked on listeners.
 	 * @param   EventInterface  $event  The event to pass to the event handlers/listeners.
 	 *                                  If not supplied, an empty EventInterface instance is created.
+	 *                                  Note, not passing an event is deprecated and will be required as of 3.0.
 	 *
 	 * @return  EventInterface
 	 *


### PR DESCRIPTION
Having the concept of a default event object inside the event dispatcher is a bit of an awkward concept as generally the dispatching code should always be creating a new event object for each dispatch.  Additionally, the behavior for this part of the API is not defined as part of the interface and is therefore only available in the concrete `Joomla\Event\Dispatcher` class (it's not usable if you're using the `Joomla\Event\DelegatingDispatcher` as an example).  Therefore, I propose to deprecate this aspect of the dispatcher in 2.0 and remove it in 3.0.

As part of this deprecation, this also deprecates omitting the `$event` argument from `Joomla\Event\DispatcherInterface::dispatch()`.  At 3.0, this will be a required argument.

Note, the CI failure here is because of a circular dependency between `joomla/console` and `joomla/event` and unrelated to this pull request.