### PR TITLE
Move the LazyServiceEventListener class from the CMS up to this package

### DIFF
--- a/Tests/LazyServiceEventListenerTest.php
+++ b/Tests/LazyServiceEventListenerTest.php
@@ -1,0 +1,253 @@
+<?php
+/**
+ * @copyright  Copyright (C) 2005 - 2019 Open Source Matters, Inc. All rights reserved.
+ * @license    GNU General Public License version 2 or later; see LICENSE.txt
+ */
+
+namespace Joomla\Event\Tests;
+
+use Joomla\Event\EventInterface;
+use Joomla\Event\LazyServiceEventListener;
+use PHPUnit\Framework\TestCase;
+use Psr\Container\ContainerInterface;
+use Psr\Container\NotFoundExceptionInterface;
+
+/**
+ * Tests for the LazyServiceEventListener class.
+ */
+class LazyServiceEventListenerTest extends TestCase
+{
+	/**
+	 * @doesNotPerformAssertions
+	 */
+	public function testListenerCanBeInstantiatedWithoutMethod()
+	{
+		$serviceId = 'lazy.object';
+
+		$container = $this->buildStubContainer();
+		$container->set(
+			$serviceId,
+			function (ContainerInterface $container)
+			{
+				return new \stdClass;
+			}
+		);
+
+		new LazyServiceEventListener($container, $serviceId);
+	}
+
+	public function testListenerCannotBeInstantiatedWithoutAServiceId()
+	{
+		$this->expectException(\InvalidArgumentException::class);
+		$this->expectExceptionMessage(
+			sprintf(
+				'The $serviceId parameter cannot be empty in %s',
+				LazyServiceEventListener::class
+			)
+		);
+
+		$container = $this->buildStubContainer();
+		$container->set(
+			'lazy.object',
+			function (ContainerInterface $container)
+			{
+				return new \stdClass;
+			}
+		);
+
+		new LazyServiceEventListener($container, '');
+	}
+
+	public function testListenerTriggersAnInvokableClass()
+	{
+		$serviceId = 'lazy.object';
+
+		$service = new class
+		{
+			private $triggered = false;
+
+			public function __invoke(): void
+			{
+				$this->triggered = true;
+			}
+
+			public function isTriggered(): bool
+			{
+				return $this->triggered;
+			}
+		};
+
+		$container = $this->buildStubContainer();
+		$container->set(
+			$serviceId,
+			function () use ($service)
+			{
+				return $service;
+			}
+		);
+
+		$event = $this->createMock(EventInterface::class);
+
+		$listener = new LazyServiceEventListener($container, $serviceId);
+		$listener($event);
+
+		$this->assertTrue($service->isTriggered());
+	}
+
+	public function testListenerTriggersAMethodOnAClass()
+	{
+		$serviceId = 'lazy.object';
+
+		$service = new class
+		{
+			private $triggered = false;
+
+			public function isTriggered(): bool
+			{
+				return $this->triggered;
+			}
+
+			public function trigger(): void
+			{
+				$this->triggered = true;
+			}
+		};
+
+		$container = $this->buildStubContainer();
+		$container->set(
+			$serviceId,
+			function () use ($service)
+			{
+				return $service;
+			}
+		);
+
+		$event = $this->createMock(EventInterface::class);
+
+		$listener = new LazyServiceEventListener($container, $serviceId, 'trigger');
+		$listener($event);
+
+		$this->assertTrue($service->isTriggered());
+	}
+
+	public function testListenerCannotTriggerAnUnknownService()
+	{
+		$this->expectException(\RuntimeException::class);
+		$this->expectExceptionMessage('The "lazy.object" service has not been registered to the service container');
+
+		$container = $this->buildStubContainer();
+
+		$event = $this->createMock(EventInterface::class);
+
+		$listener = new LazyServiceEventListener($container, 'lazy.object');
+		$listener($event);
+	}
+
+	public function testListenerCannotTriggerAMethodWhenMethodNameNotGivenAndClassNotInvokable()
+	{
+		$this->expectException(\InvalidArgumentException::class);
+		$this->expectExceptionMessage(
+			sprintf(
+				'The $method argument is required when creating a "%s" to call a method from the "lazy.object" service.',
+				LazyServiceEventListener::class
+			)
+		);
+
+		$serviceId = 'lazy.object';
+
+		$container = $this->buildStubContainer();
+		$container->set(
+			$serviceId,
+			function ()
+			{
+				return new class
+				{
+					private $triggered = false;
+
+					public function trigger(): void
+					{
+						$this->triggered = true;
+					}
+				};
+			}
+		);
+
+		$event = $this->createMock(EventInterface::class);
+
+		$listener = new LazyServiceEventListener($container, $serviceId);
+		$listener($event);
+	}
+
+	public function testListenerCannotTriggerAMethodWhenTheGivenMethodNameDoesNotExist()
+	{
+		$service = new class
+		{
+			private $triggered = false;
+
+			public function trigger(): void
+			{
+				$this->triggered = true;
+			}
+		};
+
+		$serviceId = 'lazy.object';
+
+		$this->expectException(\RuntimeException::class);
+		$this->expectExceptionMessage(
+			sprintf(
+				'The "doIt" method does not exist on "%s" (from service "%s")',
+				\get_class($service),
+				$serviceId
+			)
+		);
+
+		$container = $this->buildStubContainer();
+		$container->set(
+			$serviceId,
+			function () use ($service)
+			{
+				return $service;
+			}
+		);
+
+		$event = $this->createMock(EventInterface::class);
+
+		$listener = new LazyServiceEventListener($container, $serviceId, 'doIt');
+		$listener($event);
+	}
+
+	private function buildStubContainer(): ContainerInterface
+	{
+		return new class implements ContainerInterface
+		{
+			private $services = [];
+
+			public function get($id)
+			{
+				if (!$this->has($id))
+				{
+					throw new class extends \InvalidArgumentException implements NotFoundExceptionInterface {};
+				}
+
+				return $this->services[$id]($this);
+			}
+
+			public function has($id)
+			{
+				return isset($this->services[$id]);
+			}
+
+			public function set($id, $value)
+			{
+				if (!is_callable($value))
+				{
+					$value = function () use ($value) {
+						return $value;
+					};
+				}
+
+				$this->services[$id] = $value;
+			}
+		};
+	}
+}

--- a/composer.json
+++ b/composer.json
@@ -11,10 +11,12 @@
     "require-dev": {
         "joomla/coding-standards": "~2.0@alpha",
         "joomla/console": "~2.0",
-        "phpunit/phpunit": "~8.2"
+        "phpunit/phpunit": "~8.2",
+        "psr/container": "~1.0"
     },
     "suggest": {
-        "joomla/console": "If you want to use the DebugEventDispatcherCommand class, please install joomla/console:~2.0"
+        "joomla/console": "If you want to use the DebugEventDispatcherCommand class, please install joomla/console:~2.0",
+        "psr/container-implementation": "If you want to use the LazyServiceEventListener class, please install a PSR-11 container"
     },
     "autoload": {
         "psr-4": {

--- a/src/LazyServiceEventListener.php
+++ b/src/LazyServiceEventListener.php
@@ -1,0 +1,130 @@
+<?php
+/**
+ * Part of the Joomla Framework Event Package
+ *
+ * @copyright  Copyright (C) 2005 - 2019 Open Source Matters, Inc. All rights reserved.
+ * @license    GNU General Public License version 2 or later; see LICENSE
+ */
+
+namespace Joomla\Event;
+
+use Psr\Container\ContainerInterface;
+
+/**
+ * Decorator for an event listener to be pulled from the service container.
+ *
+ * @since  __DEPLOY_VERSION__
+ */
+final class LazyServiceEventListener
+{
+	/**
+	 * The service container to load the service from
+	 *
+	 * @var    string
+	 * @since  __DEPLOY_VERSION__
+	 */
+	private $container;
+
+	/**
+	 * The ID of the service from the container to be used
+	 *
+	 * @var    string
+	 * @since  __DEPLOY_VERSION__
+	 */
+	private $serviceId;
+
+	/**
+	 * The method from the service to be called
+	 *
+	 * @var    string
+	 * @since  __DEPLOY_VERSION__
+	 */
+	private $method;
+
+	/**
+	 * Constructor.
+	 *
+	 * @param   ContainerInterface  $container  The service container to load the service from when it shall be executed
+	 * @param   string              $serviceId  The ID of the service from the container to be used
+	 * @param   string              $method     The method from the service to be called if necessary. If left empty, the service must be a callable;
+	 *                                          (i.e. have an `__invoke()` method on a class)
+	 *
+	 * @since   __DEPLOY_VERSION__
+	 * @throws  \InvalidArgumentException if the service ID is empty
+	 */
+	public function __construct(ContainerInterface $container, string $serviceId, string $method = '')
+	{
+		if (empty($serviceId))
+		{
+			throw new \InvalidArgumentException(
+				sprintf(
+					'The $serviceId parameter cannot be empty in %s',
+					self::class
+				)
+			);
+		}
+
+		$this->container = $container;
+		$this->serviceId = $serviceId;
+		$this->method    = $method;
+	}
+
+	/**
+	 * Load a service from the container to listen to an event.
+	 *
+	 * @param   EventInterface  $event  The event to process
+	 *
+	 * @return  void
+	 *
+	 * @since   __DEPLOY_VERSION__
+	 * @throws  \InvalidArgumentException if the constructor's $method parameter is empty when not executing a callable service
+	 * @throws  \RuntimeException if the service cannot be executed
+	 */
+	public function __invoke(EventInterface $event): void
+	{
+		if (!$this->container->has($this->serviceId))
+		{
+			throw new \RuntimeException(
+				sprintf(
+					'The "%s" service has not been registered to the service container',
+					$this->serviceId
+				)
+			);
+		}
+
+		$service = $this->container->get($this->serviceId);
+
+		// If the service is callable on its own, just execute it
+		if (\is_callable($service))
+		{
+			\call_user_func($service, $event);
+
+			return;
+		}
+
+		if (empty($this->method))
+		{
+			throw new \InvalidArgumentException(
+				sprintf(
+					'The $method argument is required when creating a "%s" to call a method from the "%s" service.',
+					self::class,
+					$this->serviceId
+				)
+			);
+		}
+
+		if (!method_exists($service, $this->method))
+		{
+			throw new \RuntimeException(
+				sprintf(
+					'The "%s" method does not exist on "%s" (from service "%s")',
+					$this->method,
+					\get_class($service),
+					$this->serviceId
+				)
+			);
+		}
+
+		\call_user_func([$service, $this->method], $event);
+	}
+}


### PR DESCRIPTION
### Summary of Changes

Moves `Joomla\CMS\Event\LazyServiceEventListener` to this package and allow it to be used in more contexts than the CMS.  Generally, there shouldn't be too many occasions where the issue addressed with https://github.com/joomla/joomla-cms/pull/23708 comes into play, but if it does, this class is a good way to help with that.  The class comes over with one "major" change:

- Does not force a dependency to `joomla/di`, anything PSR-11 is acceptable
    - This causes the container to be a required constructor argument instead of something that can be set after the fact

The diff for the use of it in the CMS' Session service provider looks something like this (ignoring the file delete that should happen at the same time):

```diff
diff --git a/libraries/src/Service/Provider/Session.php b/libraries/src/Service/Provider/Session.php
index a77bf41c8e..9af5ca9572 100644
--- a/libraries/src/Service/Provider/Session.php
+++ b/libraries/src/Service/Provider/Session.php
@@ -16,7 +16,6 @@ use Joomla\CMS\Application\ApplicationHelper;
 use Joomla\CMS\Application\CMSApplicationInterface;
 use Joomla\CMS\Application\ConsoleApplication;
 use Joomla\CMS\Application\SiteApplication;
-use Joomla\CMS\Event\LazyServiceEventListener;
 use Joomla\CMS\Factory;
 use Joomla\CMS\Installation\Application\InstallationApplication;
 use Joomla\CMS\Session\EventListener\MetadataManagerListener;
@@ -28,6 +27,7 @@ use Joomla\DI\Container;
 use Joomla\DI\Exception\DependencyResolutionException;
 use Joomla\DI\ServiceProviderInterface;
 use Joomla\Event\DispatcherInterface;
+use Joomla\Event\LazyServiceEventListener;
 use Joomla\Event\Priority;
 use Joomla\Registry\Registry;
 use Joomla\Session\SessionEvents;
@@ -234,8 +234,7 @@ class Session implements ServiceProviderInterface
                                true
                        );
 
-               $listener = new LazyServiceEventListener('session.event_listener.metadata_manager', 'onAfterSessionStart');
-               $listener->setContainer($container);
+               $listener = new LazyServiceEventListener($container, 'session.event_listener.metadata_manager', 'onAfterSessionStart');
 
                /** @var DispatcherInterface $dispatcher */
                $dispatcher = $container->get(DispatcherInterface::class);
```

### Testing Instructions

Use as demonstrated in the unit test file

### Documentation Changes Required

Covered in the `docs/overview.md` file