### PR TITLE
[1.x] Deprecate the DelegatingDispatcher

### DIFF
--- a/src/DelegatingDispatcher.php
+++ b/src/DelegatingDispatcher.php
@@ -11,7 +11,8 @@ namespace Joomla\Event;
 /**
  * A dispatcher delegating its methods to an other dispatcher.
  *
- * @since  1.0
+ * @since       1.0
+ * @deprecated  2.0 Create your own delegating (decorating) dispatcher as needed.
  */
 final class DelegatingDispatcher implements DispatcherInterface
 {
@@ -19,7 +20,6 @@ final class DelegatingDispatcher implements DispatcherInterface
 	 * The delegated dispatcher.
 	 *
 	 * @var    DispatcherInterface
-	 *
 	 * @since  1.0
 	 */
 	private $dispatcher;


### PR DESCRIPTION
### Summary of Changes

The `DelegatingDispatcher` is a bit of a weird class in that it's basically a read-only dispatcher for the 1.x structure, but with the interfaces in 2.0 the class basically ends up as an awkward decorator with no extensibility.  Realistically, if you need a decorator, you're probably creating your own in full with whatever extra logic is needed.  So this PR proposes deprecating the class in the next 1.x release and removing it in 2.0.