### PR TITLE
 PHP 8.1 deprecation notices.

### DIFF
--- a/src/AbstractEvent.php
+++ b/src/AbstractEvent.php
@@ -146,6 +146,7 @@ abstract class AbstractEvent implements EventInterface, ArrayAccess, Serializabl
 	 *
 	 * @since   1.0
 	 */
+	#[\ReturnTypeWillChange]
 	public function count()
 	{
 		return \count($this->arguments);
@@ -218,6 +219,7 @@ abstract class AbstractEvent implements EventInterface, ArrayAccess, Serializabl
 	 *
 	 * @since   1.0
 	 */
+	#[\ReturnTypeWillChange]
 	public function offsetExists($name)
 	{
 		return $this->hasArgument($name);
@@ -232,6 +234,7 @@ abstract class AbstractEvent implements EventInterface, ArrayAccess, Serializabl
 	 *
 	 * @since   1.0
 	 */
+	#[\ReturnTypeWillChange]
 	public function offsetGet($name)
 	{
 		return $this->getArgument($name);

--- a/src/Event.php
+++ b/src/Event.php
@@ -123,6 +123,7 @@ class Event extends AbstractEvent
 	 * @since   1.0
 	 * @throws  InvalidArgumentException  If the argument name is null.
 	 */
+	#[\ReturnTypeWillChange]
 	public function offsetSet($name, $value)
 	{
 		if ($name === null)
@@ -142,6 +143,7 @@ class Event extends AbstractEvent
 	 *
 	 * @since   1.0
 	 */
+	#[\ReturnTypeWillChange]
 	public function offsetUnset($name)
 	{
 		$this->removeArgument($name);

--- a/src/ListenersPriorityQueue.php
+++ b/src/ListenersPriorityQueue.php
@@ -134,6 +134,7 @@ final class ListenersPriorityQueue implements \IteratorAggregate, \Countable
 	 *
 	 * @since   1.0
 	 */
+	#[\ReturnTypeWillChange]
 	public function getIterator()
 	{
 		return new \ArrayIterator($this->getAll());
@@ -146,6 +147,7 @@ final class ListenersPriorityQueue implements \IteratorAggregate, \Countable
 	 *
 	 * @since   1.0
 	 */
+	#[\ReturnTypeWillChange]
 	public function count()
 	{
 		$count = 0;


### PR DESCRIPTION
Pull Request for Issue #

### Summary of Changes
Silencing  PHP 8.1 deprecation notices that prevents Joomla! from running with error reporting on.
Example of error message:
PHP Deprecated:  Return type of Joomla\Event\ListenersPriorityQueue::getIterator() should either be compatible with IteratorAggregate::getIterator(): Traversable, or the #[\ReturnTypeWillChange] attribute should be used to temporarily suppress the notice in D:\virtualhosts\clean40\libraries\vendor\joomla\event\src\ListenersPriorityQueue.php on line 137

Snip from PHP.net Backward Incompatible Changes:

![image](https://user-images.githubusercontent.com/25645600/145457369-e2912f0b-e241-481d-977a-ffd42aaef0fa.png)

### Testing Instructions
Code review or check that errors disappear from logfile.

### Documentation Changes Required
Probably not.