### PR TITLE
Update composer.json

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -6,7 +6,7 @@
     "homepage": "https://github.com/joomla-framework/event",
     "license": "GPL-2.0-or-later",
     "require": {
-        "php": "^7.2.5",
+        "php": "^7.2.5|^8.0",
         "symfony/deprecation-contracts": "^2.1"
     },
     "require-dev": {


### PR DESCRIPTION
Fix #29

Pull Request for Issue #

### Summary of Changes
add php ^7.2.5|^8.0 to make it work with the joomla/database:^2.1 composer package
### Testing Instructions
composer require joomla/database:^2.1
it should install it without php requirements errors even if we are using php 8.0.16 for example
### Documentation Changes Required
I don't think so. Composer is the judge here.

