### PR TITLE
A better description for getSubscribedEvents

### DIFF
--- a/src/SubscriberInterface.php
+++ b/src/SubscriberInterface.php
@@ -17,6 +17,8 @@ interface SubscriberInterface
 {
 	/**
 	 * Returns an array of events this subscriber will listen to.
+	 * The code must not depend on runtime state. 
+	 * All logic depending on runtime state must be put into the individual methods handling the events.
 	 *
 	 * The array keys are event names and the value can be:
 	 *


### PR DESCRIPTION
### Summary of Changes

Clarify why the getSubscribedEvents method is static, in SubscriberInterface.

### Testing Instructions

Review

### Documentation Changes Required

None