### PR TITLE
Dispatcher with optinal error handler

### DIFF
--- a/src/DispatcherWithErrorHandlerInterface.php
+++ b/src/DispatcherWithErrorHandlerInterface.php
@@ -1,0 +1,29 @@
+<?php
+
+/**
+ * Part of the Joomla Framework Event Package
+ *
+ * @copyright  Copyright (C) 2005 - 2023 Open Source Matters, Inc. All rights reserved.
+ * @license    GNU General Public License version 2 or later; see LICENSE
+ */
+
+namespace Joomla\Event;
+
+/**
+ * Interface for dispatcher with error handler.
+ *
+ * @since  __DEPLOY_VERSION__
+ */
+interface DispatcherWithErrorHandlerInterface
+{
+    /**
+     * Set error handler for the dispatcher to handler errors in an event listeners.
+     *
+     * @param  ?callable   $handler  The error handler
+     *
+     * @return ?callable  Previous error handler
+     *
+     * @since  __DEPLOY_VERSION__
+     */
+    public function setErrorHandler(?callable $handler): ?callable;
+}


### PR DESCRIPTION
This is alternative to #34

### Summary of Changes

The changes allows to set an error handler, that will be executed when event listener throws an error.
```php
$dispatcher->setErrorHandler(function($error, $event) {
  var_dump($error, $event);
});
```

### Testing Instructions

Test pases

### Documentation Changes Required

New feature
