### PR TITLE
Add Profiling to Dispatcher

### DIFF
--- a/src/Dispatcher.php
+++ b/src/Dispatcher.php
@@ -247,7 +247,7 @@ class Dispatcher implements DispatcherInterface
         }
 
         // Basic Profiling for Plugins
-        if (constant('JDEBUG')) {
+        if (JDEBUG) {
             $classObj = '';
             $plgName = '';
 

--- a/src/Dispatcher.php
+++ b/src/Dispatcher.php
@@ -246,6 +246,27 @@ class Dispatcher implements DispatcherInterface
             $this->listeners[$eventName] = new ListenersPriorityQueue();
         }
 
+        // Basic Profiling for Plugins
+        if (constant('JDEBUG')) {
+            $classObj = '';
+            $plgName = '';
+
+            // Try getting the reference to the Class
+            $classObj = debug_backtrace()[1]['object'];
+
+            if ($classObj) {
+                // If we have found a reference get the Name
+                $plgName = get_class($classObj);
+            }
+
+            // Wrapping the Callback to get the time it executed
+            $callback = function (...$args) use($callback, $plgName, $eventName) {
+                \Joomla\CMS\Profiler\Profiler::getInstance('Application')->mark('beforeExecutePlugin ' . $plgName.'::'.$eventName);
+                $callback(...$args);
+                \Joomla\CMS\Profiler\Profiler::getInstance('Application')->mark('afterExecutePlugin ' . $plgName.'::'.$eventName);
+            };
+        }
+
         $this->listeners[$eventName]->add($callback, $priority);
 
         return true;


### PR DESCRIPTION
### Summary of Changes
Added Basic Profiling for Plugins in Joomla. Just like we already have for modules and components.

One Problem is that something is happening after the `afterExecutePlugin Joomla\CMS\Service\Provider\Session::session.start` that takes some time that isn't profiled correctly for now. Because of that the `beforeExecutePlugin` right after the session.start can be a bit misleading. But at least we have a basic understanding of which plugins slow down a page.

![image](https://github.com/user-attachments/assets/4beea149-f5d5-4cbf-8a58-e3f46f672e4f)


### Testing Instructions
1. Enable Debugging and Profiling
2. Load a Page and look for `beforeExecutePlugin` `afterExecutePlugin`

### Documentation Changes Required
