### PR TITLE
[4.x] resolve PHPUnit Notices

### DIFF
--- a/Tests/LazyServiceEventListenerTest.php
+++ b/Tests/LazyServiceEventListenerTest.php
@@ -8,6 +8,7 @@ namespace Joomla\Event\Tests;
 
 use Joomla\Event\EventInterface;
 use Joomla\Event\LazyServiceEventListener;
+use PHPUnit\Framework\Attributes\DoesNotPerformAssertions;
 use PHPUnit\Framework\TestCase;
 use Psr\Container\ContainerInterface;
 use Psr\Container\NotFoundExceptionInterface;
@@ -21,9 +22,8 @@ class LazyServiceEventListenerTest extends TestCase
      * @testdox  The listener can be instantiated without a method name
      *
      * @covers   Joomla\Event\LazyServiceEventListener
-     *
-     * @doesNotPerformAssertions
      */
+    #[DoesNotPerformAssertions]
     public function testListenerCanBeInstantiatedWithoutMethod()
     {
         $serviceId = 'lazy.object';
@@ -96,7 +96,7 @@ class LazyServiceEventListenerTest extends TestCase
             }
         );
 
-        $event = $this->createMock(EventInterface::class);
+        $event = $this->createStub(EventInterface::class);
 
         $listener = new LazyServiceEventListener($container, $serviceId);
         $listener($event);
@@ -135,7 +135,7 @@ class LazyServiceEventListenerTest extends TestCase
             }
         );
 
-        $event = $this->createMock(EventInterface::class);
+        $event = $this->createStub(EventInterface::class);
 
         $listener = new LazyServiceEventListener($container, $serviceId, 'trigger');
         $listener($event);
@@ -155,7 +155,7 @@ class LazyServiceEventListenerTest extends TestCase
 
         $container = $this->buildStubContainer();
 
-        $event = $this->createMock(EventInterface::class);
+        $event = $this->createStub(EventInterface::class);
 
         $listener = new LazyServiceEventListener($container, 'lazy.object');
         $listener($event);
@@ -193,7 +193,7 @@ class LazyServiceEventListenerTest extends TestCase
             }
         );
 
-        $event = $this->createMock(EventInterface::class);
+        $event = $this->createStub(EventInterface::class);
 
         $listener = new LazyServiceEventListener($container, $serviceId);
         $listener($event);
@@ -234,7 +234,7 @@ class LazyServiceEventListenerTest extends TestCase
             }
         );
 
-        $event = $this->createMock(EventInterface::class);
+        $event = $this->createStub(EventInterface::class);
 
         $listener = new LazyServiceEventListener($container, $serviceId, 'doIt');
         $listener($event);


### PR DESCRIPTION
### Summary of Changes

resolve PHPUnit Notices

### Testing Instructions

check output of PHPUnit

_The pull request cannot be reviewed at the moment because Composer fails to resolve dependencies, as the root package joomla/event is on a dev branch that conflicts with the required stable version._

### Actual result BEFORE applying this Pull Request

```
OK, but there were issues!
Tests: 65, Assertions: 187, PHPUnit Notices: 5, Risky: 1.
```

### Expected result AFTER applying this Pull Request

```
OK (65 tests, 187 assertions)
```

### Documentation Changes Required

no